### PR TITLE
Hash rate refactoring & JSON support

### DIFF
--- a/hashrate-json.php
+++ b/hashrate-json.php
@@ -1,0 +1,59 @@
+<?
+
+require_once 'includes.php';
+
+require_once 'hashrate.php';
+
+if (!isset($_SERVER['PATH_INFO']))
+{
+	print json_encode(array("error" => "No username specified in URL path  Please try again."));
+	exit;
+}
+
+$link = pg_pconnect("dbname=$psqldb user=$psqluser password='$psqlpass' host=$psqlhost");
+
+if (pg_connection_status($link) != PGSQL_CONNECTION_OK)
+{
+	pg_close($link);
+
+	$link = pg_pconnect("dbname=$psqldb user=$psqluser password='$psqlpass' host=$psqlhost");
+
+	if (pg_connection_status($link) != PGSQL_CONNECTION_OK)
+	{
+		print json_encode(array("error" => "Unable to establish a connection to the stats database.  Please try again later. If this issue persists, please report it to the pool operator."));
+		exit;
+	}
+}
+
+$givenuser = substr($_SERVER['PATH_INFO'],1,strlen($_SERVER['PATH_INFO'])-1);
+$bits =  hex2bits(\Bitcoin::addressToHash160($givenuser));
+
+$sql = "select id from public.users where keyhash='$bits' order by id asc limit 1";
+$result = pg_exec($link, $sql);
+$numrows = pg_numrows($result);
+
+if (!$numrows)
+{
+	print json_encode(array("error" => "Username $givenuser not found in database.  Please try again later. If this issue persists, please report it to the pool operator."));
+	exit;
+}
+
+$row = pg_fetch_array($result, 0);
+$user_id = $row["id"];
+
+$cache_key = hash("sha256", "hashrate-json.php hashrate JSON for $givenuser with id $user_id");
+
+$json = get_stats_cache($link, 11, $cache_key);
+
+if ($json == "")
+{
+	$hashrate_info = get_hashrate_stats($link, $givenuser, $user_id);
+
+	$json = json_encode($hashrate_info);
+
+	set_stats_cache($link, 11, $cache_key, $json, 30);
+}
+
+print $json;
+
+?>

--- a/hashrate.php
+++ b/hashrate.php
@@ -4,49 +4,49 @@ require_once 'includes.php';
 
 function add_interval_stats(&$set, $interval, $interval_name, $hashrate, $shares)
 {
-  $set[$interval] = array("interval" => $interval, "interval_name" => $interval_name, "hashrate" => $hashrate, "shares" => $shares);
+	$set[$interval] = array("interval" => $interval, "interval_name" => $interval_name, "hashrate" => $hashrate, "shares" => $shares);
 
-  if (!array_key_exists("intervals", $set))
-    $set["intervals"] = array();
+	if (!array_key_exists("intervals", $set))
+		$set["intervals"] = array();
 
-  $intervals = &$set["intervals"];
-  $intervals[] = $interval;
+	$intervals = &$set["intervals"];
+	$intervals[] = $interval;
 }
 
 function get_hashrate_stats(&$link, $givenuser, $user_id)
 {
-  global $psqlschema, $serverid;
+	global $psqlschema, $serverid;
 
-  # 3 hour hashrate
-  $sql = "select (sum(accepted_shares)*pow(2,32))/10800 as avghash,sum(accepted_shares) as share_total from $psqlschema.stats_shareagg where server=$serverid and user_id=$user_id and time > to_timestamp((date_part('epoch', (select time from $psqlschema.stats_shareagg where server=$serverid group by server,time order by time desc limit 1)-'3 hours'::interval)::integer / 675::integer) * 675::integer)";
-  $result = pg_exec($link, $sql); $row = pg_fetch_array($result, 0);
-  $u16avghash = isset($row["avghash"])?$row["avghash"]:0;
-  $u16shares = isset($row["share_total"])?$row["share_total"]:0;
+	# 3 hour hashrate
+	$sql = "select (sum(accepted_shares)*pow(2,32))/10800 as avghash,sum(accepted_shares) as share_total from $psqlschema.stats_shareagg where server=$serverid and user_id=$user_id and time > to_timestamp((date_part('epoch', (select time from $psqlschema.stats_shareagg where server=$serverid group by server,time order by time desc limit 1)-'3 hours'::interval)::integer / 675::integer) * 675::integer)";
+	$result = pg_exec($link, $sql); $row = pg_fetch_array($result, 0);
+	$u16avghash = isset($row["avghash"])?$row["avghash"]:0;
+	$u16shares = isset($row["share_total"])?$row["share_total"]:0;
 
-  # 22.5 minute hashrate
-  $sql = "select (sum(accepted_shares)*pow(2,32))/1350 as avghash,sum(accepted_shares) as share_total from $psqlschema.stats_shareagg where server=$serverid and user_id=$user_id and time > to_timestamp((date_part('epoch', (select time from $psqlschema.stats_shareagg where server=$serverid group by server,time order by time desc limit 1))::integer / 675::integer)::integer * 675::integer)-'1350 seconds'::interval";
-  $result = pg_exec($link, $sql); $row = pg_fetch_array($result, 0);
-  $u2avghash = isset($row["avghash"])?$row["avghash"]:0;
-  $u2shares = isset($row["share_total"])?$row["share_total"]:0;
+	# 22.5 minute hashrate
+	$sql = "select (sum(accepted_shares)*pow(2,32))/1350 as avghash,sum(accepted_shares) as share_total from $psqlschema.stats_shareagg where server=$serverid and user_id=$user_id and time > to_timestamp((date_part('epoch', (select time from $psqlschema.stats_shareagg where server=$serverid group by server,time order by time desc limit 1))::integer / 675::integer)::integer * 675::integer)-'1350 seconds'::interval";
+	$result = pg_exec($link, $sql); $row = pg_fetch_array($result, 0);
+	$u2avghash = isset($row["avghash"])?$row["avghash"]:0;
+	$u2shares = isset($row["share_total"])?$row["share_total"]:0;
 
-  # instant hashrates from CPPSRB
-  $cppsrbjson = file_get_contents("/var/lib/eligius/$serverid/cppsrb.json");
-  $cppsrbjsondec = json_decode($cppsrbjson,true);
-  $mycppsrb = $cppsrbjsondec[$givenuser];
-  $globalccpsrb = $cppsrbjsondec[""];
-  $cppsrbloaded = 1;
-  $my_shares = $mycppsrb["shares"];
+	# instant hashrates from CPPSRB
+	$cppsrbjson = file_get_contents("/var/lib/eligius/$serverid/cppsrb.json");
+	$cppsrbjsondec = json_decode($cppsrbjson,true);
+	$mycppsrb = $cppsrbjsondec[$givenuser];
+	$globalccpsrb = $cppsrbjsondec[""];
+	$cppsrbloaded = 1;
+	$my_shares = $mycppsrb["shares"];
 
-  # build up return value, an array of maps containing structured information about the hash rate over each interval
-  $return_value = array();
+	# build up return value, an array of maps containing structured information about the hash rate over each interval
+	$return_value = array();
 
-  add_interval_stats($return_value, 10800, "3 hours", $u16avghash, $u16shares);
-  add_interval_stats($return_value, 1350, "22.5 minutes", $u2avghash, $u2shares);
+	add_interval_stats($return_value, 10800, "3 hours", floatval($u16avghash), intval($u16shares));
+	add_interval_stats($return_value, 1350, "22.5 minutes", floatval($u2avghash), intval($u2shares));
 
-  for ($i = 256; $i > 127; $i = $i / 2)
-    add_interval_stats($return_value, $i, "$i seconds", ($my_shares[$i] * 4294967296) / $i, round($my_shares[$i]));
+	for ($i = 256; $i > 127; $i = $i / 2)
+		add_interval_stats($return_value, $i, "$i seconds", ($my_shares[$i] * 4294967296) / $i, round($my_shares[$i]));
 
-  return $return_value;
+	return $return_value;
 }
 
 ?>

--- a/hashrate.php
+++ b/hashrate.php
@@ -1,0 +1,52 @@
+<?
+
+require_once 'includes.php';
+
+function add_interval_stats(&$set, $interval, $interval_name, $hashrate, $shares)
+{
+  $set[$interval] = array("interval" => $interval, "interval_name" => $interval_name, "hashrate" => $hashrate, "shares" => $shares);
+
+  if (!array_key_exists("intervals", $set))
+    $set["intervals"] = array();
+
+  $intervals = &$set["intervals"];
+  $intervals[] = $interval;
+}
+
+function get_hashrate_stats(&$link, $givenuser, $user_id)
+{
+  global $psqlschema, $serverid;
+
+  # 3 hour hashrate
+  $sql = "select (sum(accepted_shares)*pow(2,32))/10800 as avghash,sum(accepted_shares) as share_total from $psqlschema.stats_shareagg where server=$serverid and user_id=$user_id and time > to_timestamp((date_part('epoch', (select time from $psqlschema.stats_shareagg where server=$serverid group by server,time order by time desc limit 1)-'3 hours'::interval)::integer / 675::integer) * 675::integer)";
+  $result = pg_exec($link, $sql); $row = pg_fetch_array($result, 0);
+  $u16avghash = isset($row["avghash"])?$row["avghash"]:0;
+  $u16shares = isset($row["share_total"])?$row["share_total"]:0;
+
+  # 22.5 minute hashrate
+  $sql = "select (sum(accepted_shares)*pow(2,32))/1350 as avghash,sum(accepted_shares) as share_total from $psqlschema.stats_shareagg where server=$serverid and user_id=$user_id and time > to_timestamp((date_part('epoch', (select time from $psqlschema.stats_shareagg where server=$serverid group by server,time order by time desc limit 1))::integer / 675::integer)::integer * 675::integer)-'1350 seconds'::interval";
+  $result = pg_exec($link, $sql); $row = pg_fetch_array($result, 0);
+  $u2avghash = isset($row["avghash"])?$row["avghash"]:0;
+  $u2shares = isset($row["share_total"])?$row["share_total"]:0;
+
+  # instant hashrates from CPPSRB
+  $cppsrbjson = file_get_contents("/var/lib/eligius/$serverid/cppsrb.json");
+  $cppsrbjsondec = json_decode($cppsrbjson,true);
+  $mycppsrb = $cppsrbjsondec[$givenuser];
+  $globalccpsrb = $cppsrbjsondec[""];
+  $cppsrbloaded = 1;
+  $my_shares = $mycppsrb["shares"];
+
+  # build up return value, an array of maps containing structured information about the hash rate over each interval
+  $return_value = array();
+
+  add_interval_stats($return_value, 10800, "3 hours", $u16avghash, $u16shares);
+  add_interval_stats($return_value, 1350, "22.5 minutes", $u2avghash, $u2shares);
+
+  for ($i = 256; $i > 127; $i = $i / 2)
+    add_interval_stats($return_value, $i, "$i seconds", ($my_shares[$i] * 4294967296) / $i, round($my_shares[$i]));
+
+  return $return_value;
+}
+
+?>


### PR DESCRIPTION
Added support for a separate endpoint returning hashrate stats in JSON format:
- Factored the hashrate computation logic out of userstats.php into new file hashrate.php.
- Added new endpoint hashrate-json.php that uses hashrate.php in much the same way as userstats.php, but outputs only the hashrate table information formatted as JSON.

The refactored code used to assign to local variables $u16avghash, $u16shares, $u2avghash, $u2shares and then an array $my_shares with entries for 256- and 128-second intervals. Its updated form consolidates all of these down to a single object, and that object is structured as a set of maps. Each map has the same set of properties, so that they can be processed identically by a caller. A typical object looks like this (once encoded in JSON):

``` json
{
  "intervals":[10800,1350,256,128],
  "10800":{"interval":10800,"interval_name":"3 hours","hashrate":819225243.4963,"shares":2060},
  "1350":{"interval":1350,"interval_name":"22.5 minutes","hashrate":814453057.61185,"shares":256},
  "256":{"interval":256,"interval_name":"256 seconds","hashrate":805306368,"shares":48},
  "128":{"interval":128,"interval_name":"128 seconds","hashrate":637534208,"shares":19}
}
```

This object provides everything that userstats.php needs to generate its table, and is also exactly the data that I want to be able to export as JSON.
